### PR TITLE
Add stack.yaml to build project with stack.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 *.hi
 *.o
+.stack-work

--- a/chesskell.cabal
+++ b/chesskell.cabal
@@ -3,22 +3,20 @@
 
 name:                chesskell
 version:             0.1.0.0
--- synopsis:            
--- description:         
--- license:             
-license-file:        LICENSE
 author:              Ryan DV
 maintainer:          rdevilla@uwaterloo.ca
--- copyright:           
 category:            Game
 build-type:          Simple
--- extra-source-files:  
 cabal-version:       >=1.10
 
 executable chesskell
   main-is: Chesskell.hs
   hs-source-dirs: src
-  -- other-modules:       
+  other-modules:  Chess.AI
+                , Chess.Base
+                , Chess.FenParser
+                , Chess.Game
+                , Chess.MoveGen
   other-extensions:    TupleSections
   build-depends:       aeson >= 0.6,
                        base >=4.7,
@@ -27,7 +25,7 @@ executable chesskell
                        hspec >=2.1.0,
                        mtl >=2.1,
                        parsec >=3.1 && <3.2,
-                       QuickCheck >=2.6 && <2.7
+                       QuickCheck >=2.6 && <2.9
 
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,20 @@
+# Resolver to choose a 'specific' stackage snapshot or a compiler version.
+# A snapshot resolver dictates the compiler version and the set of packages
+# to be used for project dependencies. For example:
+# 
+resolver: lts-6.12
+
+# A package marked 'extra-dep: true' will only be built if demanded by a
+# non-dependency (i.e. a user package), and its test suites and benchmarks
+# will not be run. This is useful for tweaking upstream packages.
+packages:
+- '.'
+# Dependency packages to be pulled from upstream that are not in the resolver
+# (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []


### PR DESCRIPTION
I haven't tried to compile the QuickCheck tests, but the main module compiles and runs nicely.
I had to relax the QuickCheck upper bound to compile using stack, since it needs the version **2.8.2** available in [lts-6.12](https://www.stackage.org/lts-6.12).

I've also added the missing modules to `other-modules` in the cabal file for this can cause some compilation problems.